### PR TITLE
Patch: Fix: Minor code linting issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,6 +59,5 @@ def main():
             print("No CNN features extracted")
 
 
-
 if __name__ == "__main__":
     main()

--- a/src/preprocessing/histograms.py
+++ b/src/preprocessing/histograms.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 import cv2
 import numpy as np
@@ -31,9 +31,9 @@ def compute_histograms_for_window(
     for y in range(0, h - window_size + 1, window_size):
         for x in range(0, w - window_size + 1, window_size):
             # Extract windows from the pre-split channels
-            window_r = r_channel[y: y + window_size, x: x + window_size]
-            window_g = g_channel[y: y + window_size, x: x + window_size]
-            window_b = b_channel[y: y + window_size, x: x + window_size]
+            window_r = r_channel[y : y + window_size, x : x + window_size]
+            window_g = g_channel[y : y + window_size, x : x + window_size]
+            window_b = b_channel[y : y + window_size, x : x + window_size]
 
             # Use NumPy's bincount for a much faster histogram calculation.
             hist_r = np.bincount(window_r.flatten(), minlength=256).tolist()
@@ -54,55 +54,55 @@ def compute_histograms_for_window(
 
 
 def concatenate_histograms_to_matrix(
-    histograms: List[HistogramData]
-) -> np.ndarray:
+    histograms: List[HistogramData],
+) -> np.ndarray[Any, Any]:
     """
     Concatenates RGB histograms from multiple windows into a single matrix.
-    
+
     For each window, concatenates the red, green, and blue channel histograms
     into a single feature vector of size 768 (256×3). The result is a matrix
     of shape (num_windows, 768) suitable for CNN input.
-    
+
     Args:
         histograms (List[HistogramData]): List of histogram data dictionaries
             returned by compute_histograms_for_window.
-    
+
     Returns:
         np.ndarray: Matrix of shape (num_windows, 768) where each row represents
             the concatenated RGB histograms for one window.
     """
     if not histograms:
         return np.array([])
-    
+
     num_windows = len(histograms)
     feature_matrix = np.zeros((num_windows, 768), dtype=np.float64)
-    
+
     for i, hist_data in enumerate(histograms):
         # Concatenate RGB histograms: [R, G, B] -> single vector of length 768
         hist_r = np.array(hist_data["hist_r"], dtype=np.float64)
         hist_g = np.array(hist_data["hist_g"], dtype=np.float64)
         hist_b = np.array(hist_data["hist_b"], dtype=np.float64)
-        
+
         # Concatenate along the feature dimension
         concatenated_features = np.concatenate([hist_r, hist_g, hist_b])
         feature_matrix[i, :] = concatenated_features
-    
+
     return feature_matrix
 
 
 def get_histogram_matrix_for_cnn(
     image: MatLike, cfg: ProjectSettings
-) -> np.ndarray:
+) -> np.ndarray[Any, Any]:
     """
     Computes histograms and returns them as a concatenated matrix for CNN input.
-    
+
     This is a convenience function that combines compute_histograms_for_window
     and concatenate_histograms_to_matrix into a single call.
-    
+
     Args:
         image (cv2.typing.MatLike): The input image (aligned face).
         cfg (ProjectSettings): Configuration settings containing window size.
-    
+
     Returns:
         np.ndarray: Matrix of shape (num_windows, 768) ready for CNN input.
     """
@@ -115,14 +115,14 @@ def get_cnn_histogram_features(
 ) -> CNNHistogramFeatures:
     """
     Computes histograms and returns them as a structured CNNHistogramFeatures object.
-    
+
     This function provides the most complete interface, returning both the raw
     matrix and metadata about the features.
-    
+
     Args:
         image (cv2.typing.MatLike): The input image (aligned face).
         cfg (ProjectSettings): Configuration settings containing window size.
-    
+
     Returns:
         CNNHistogramFeatures: A structured object containing the feature matrix
             and metadata suitable for CNN input.

--- a/src/schemas/features.py
+++ b/src/schemas/features.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel
 
 from src.schemas.custom_types import NumpyArray
@@ -24,11 +25,11 @@ class DetectedFeatures(BaseModel):
 class CNNHistogramFeatures(BaseModel):
     """
     A Pydantic model to represent concatenated histogram features for CNN input.
-    
+
     The concatenated matrix combines RGB channel histograms for each window,
     resulting in a feature matrix of shape (num_windows, 768) where each row
     represents the concatenated [R, G, B] histograms for one window.
-    
+
     Attributes:
         feature_matrix (NumpyArray): Matrix of shape (num_windows, 768) where
             each row contains concatenated RGB histograms for one window.
@@ -36,21 +37,23 @@ class CNNHistogramFeatures(BaseModel):
         feature_dimension (int): Feature dimension per window (768 = 256×3 RGB channels).
         window_size (int): Size of the sliding window used.
     """
-    
-    feature_matrix: NumpyArray
+
+    feature_matrix: np.ndarray[Any, Any]
     num_windows: int
     feature_dimension: int
     window_size: int
-    
+
     @classmethod
-    def from_histogram_matrix(cls, matrix: NumpyArray, window_size: int) -> "CNNHistogramFeatures":
+    def from_histogram_matrix(
+        cls, matrix: np.ndarray[Any, Any], window_size: int
+    ) -> "CNNHistogramFeatures":
         """
         Create CNNHistogramFeatures from a histogram matrix.
-        
+
         Args:
-            matrix (NumpyArray): The concatenated histogram matrix.
+            matrix (np.ndarray[Any, Any]): The concatenated histogram matrix.
             window_size (int): The window size used for histogram computation.
-            
+
         Returns:
             CNNHistogramFeatures: A new instance with computed metadata.
         """
@@ -59,12 +62,12 @@ class CNNHistogramFeatures(BaseModel):
                 feature_matrix=matrix,
                 num_windows=0,
                 feature_dimension=0,
-                window_size=window_size
+                window_size=window_size,
             )
-        
+
         return cls(
             feature_matrix=matrix,
             num_windows=matrix.shape[0],
             feature_dimension=matrix.shape[1],
-            window_size=window_size
+            window_size=window_size,
         )


### PR DESCRIPTION
This pull request updates type annotations throughout the histogram feature extraction code to use more explicit NumPy array typing and improves consistency between modules. The changes primarily affect how histogram matrices are typed and passed between preprocessing and schema layers.

**Type annotation improvements:**

* Updated type annotations in `src/preprocessing/histograms.py` for functions that return or accept histogram matrices to use `np.ndarray[Any, Any]` for better clarity and compatibility. [[1]](diffhunk://#diff-33cec53706671c3b33abf6370ab71ad1eb57417870c16c5855dcfa90348a0824L1-R1) [[2]](diffhunk://#diff-33cec53706671c3b33abf6370ab71ad1eb57417870c16c5855dcfa90348a0824L57-R58) [[3]](diffhunk://#diff-33cec53706671c3b33abf6370ab71ad1eb57417870c16c5855dcfa90348a0824L95-R95)
* Modified the `CNNHistogramFeatures` model in `src/schemas/features.py` to use `np.ndarray[Any, Any]` instead of the custom `NumpyArray` type, and updated the `from_histogram_matrix` class method accordingly. [[1]](diffhunk://#diff-1fdc3764c49c956b02a44e3829e759edaf17f57af85c6bc40d1cf326a27b1576R3) [[2]](diffhunk://#diff-1fdc3764c49c956b02a44e3829e759edaf17f57af85c6bc40d1cf326a27b1576L40-R54)

**Minor formatting and consistency:**

* Added commas for consistency in argument lists and return statements in `src/schemas/features.py`.

No functional changes were made to the feature extraction logic; these updates are focused on code clarity and maintainability.